### PR TITLE
Update MANDCONTANDSIN_XML_CONSTRAINT_2.json

### DIFF
--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDSIN_XML_CONSTRAINT_2.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDSIN_XML_CONSTRAINT_2.json
@@ -13,7 +13,7 @@
 		},
 		{"text":"contains both a"},
 		{
-			"name":"Subelement",
+			"name":"Property",
 			"params":[2],
 			"exampleValue":"element",
 			"description":"element condition"


### PR DESCRIPTION
Subelement and text do not make sense for LIDO here. Property and text would be theoretically possible, even though I cannot think of a use case at the moment: one could check whether an element contains both a specific attribute and text (i.e., is not empty). Therefore, I suggest property instead of subelement.