### PR TITLE
Add a custom JSONObject to variants and constraints for future features

### DIFF
--- a/qualitypatternmodel.edit/plugin.properties
+++ b/qualitypatternmodel.edit/plugin.properties
@@ -465,3 +465,4 @@ _UI_NeoPlace_FOLLOWING_literal = FOLLOWING
 _UI_TextParam_type = Text Param
 _UI_TextParam_contains_feature = Contains
 _UI_TextParam_matches_feature = Matches
+_UI_PatternText_custom_feature = Custom

--- a/qualitypatternmodel.edit/src/qualitypatternmodel/textrepresentation/provider/PatternTextItemProvider.java
+++ b/qualitypatternmodel.edit/src/qualitypatternmodel/textrepresentation/provider/PatternTextItemProvider.java
@@ -68,6 +68,7 @@ public class PatternTextItemProvider
 			addNamePropertyDescriptor(object);
 			addFragmentsOrderedPropertyDescriptor(object);
 			addTypeConstraintPropertyDescriptor(object);
+			addCustomPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
@@ -134,6 +135,28 @@ public class PatternTextItemProvider
 				 false,
 				 false,
 				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 null,
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Custom feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addCustomPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_PatternText_custom_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_PatternText_custom_feature", "_UI_PatternText_type"),
+				 TextrepresentationPackage.Literals.PATTERN_TEXT__CUSTOM,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
 				 null,
 				 null));
 	}
@@ -209,6 +232,7 @@ public class PatternTextItemProvider
 		switch (notification.getFeatureID(PatternText.class)) {
 			case TextrepresentationPackage.PATTERN_TEXT__NAME:
 			case TextrepresentationPackage.PATTERN_TEXT__TYPE_CONSTRAINT:
+			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 				return;
 			case TextrepresentationPackage.PATTERN_TEXT__FRAGMENTS:

--- a/qualitypatternmodel.tests/src/qualitypatternmodel/textrepresentation/tests/PatternTextTest.java
+++ b/qualitypatternmodel.tests/src/qualitypatternmodel/textrepresentation/tests/PatternTextTest.java
@@ -25,6 +25,7 @@ import qualitypatternmodel.textrepresentation.TextrepresentationFactory;
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateSparqlTemplate() <em>Generate Sparql Template</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateJSONObject() <em>Generate JSON Object</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateVariantJSONObject() <em>Generate Variant JSON Object</em>}</li>
+ *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson() <em>Generate Custom As Json</em>}</li>
  * </ul>
  * </p>
  * @generated
@@ -212,6 +213,19 @@ public class PatternTextTest extends TestCase {
 	 * @generated
 	 */
 	public void testGenerateVariantJSONObject() {
+		// TODO: implement this operation test method
+		// Ensure that you remove @generated or mark it @generated NOT
+		fail();
+	}
+
+	/**
+	 * Tests the '{@link qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson() <em>Generate Custom As Json</em>}' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson()
+	 * @generated
+	 */
+	public void testGenerateCustomAsJson() {
 		// TODO: implement this operation test method
 		// Ensure that you remove @generated or mark it @generated NOT
 		fail();

--- a/qualitypatternmodel.tests/src/qualitypatternmodel/textrepresentation/tests/PatternTextTest.java
+++ b/qualitypatternmodel.tests/src/qualitypatternmodel/textrepresentation/tests/PatternTextTest.java
@@ -25,7 +25,7 @@ import qualitypatternmodel.textrepresentation.TextrepresentationFactory;
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateSparqlTemplate() <em>Generate Sparql Template</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateJSONObject() <em>Generate JSON Object</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateVariantJSONObject() <em>Generate Variant JSON Object</em>}</li>
- *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson() <em>Generate Custom As Json</em>}</li>
+ *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#addToCustom(org.json.JSONObject) <em>Add To Custom</em>}</li>
  * </ul>
  * </p>
  * @generated
@@ -219,13 +219,13 @@ public class PatternTextTest extends TestCase {
 	}
 
 	/**
-	 * Tests the '{@link qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson() <em>Generate Custom As Json</em>}' operation.
+	 * Tests the '{@link qualitypatternmodel.textrepresentation.PatternText#addToCustom(org.json.JSONObject) <em>Add To Custom</em>}' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson()
+	 * @see qualitypatternmodel.textrepresentation.PatternText#addToCustom(org.json.JSONObject)
 	 * @generated
 	 */
-	public void testGenerateCustomAsJson() {
+	public void testAddToCustom__JSONObject() {
 		// TODO: implement this operation test method
 		// Ensure that you remove @generated or mark it @generated NOT
 		fail();

--- a/qualitypatternmodel/model/qualitypatternmodel.ecore
+++ b/qualitypatternmodel/model/qualitypatternmodel.ecore
@@ -942,8 +942,7 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="fragmentsOrdered" unique="false"
           lowerBound="1" upperBound="-1" eType="#//textrepresentation/Fragment"/>
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="typeConstraint" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
-      <eStructuralFeatures xsi:type="ecore:EAttribute" name="custom" eType="#//textrepresentation/JSONObjectWrapper"
-          transient="true"/>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="custom" eType="#//textrepresentation/JSONObjectWrapper"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="ParameterFragment" eSuperTypes="#//textrepresentation/Fragment #//textrepresentation/ParameterReference">
       <eOperations name="getType" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/qualitypatternmodel/model/qualitypatternmodel.ecore
+++ b/qualitypatternmodel/model/qualitypatternmodel.ecore
@@ -927,7 +927,9 @@
           eExceptions="#//patternstructure/InvalidityExceptionWrapper #//operators/OperatorCycleExceptionWrapper #//patternstructure/MissingPatternContainerException"/>
       <eOperations name="generateJSONObject" eType="#//textrepresentation/JSONObjectWrapper"/>
       <eOperations name="generateVariantJSONObject" eType="#//textrepresentation/JSONObjectWrapper"/>
-      <eOperations name="generateCustomAsJson" eType="#//textrepresentation/JSONObjectWrapper"/>
+      <eOperations name="addToCustom">
+        <eParameters name="addition" eType="#//textrepresentation/JSONObjectWrapper"/>
+      </eOperations>
       <eStructuralFeatures xsi:type="ecore:EReference" name="pattern" lowerBound="1"
           eType="#//patternstructure/CompletePattern" eOpposite="#//patternstructure/CompletePattern/text"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="fragments" lowerBound="1"
@@ -940,12 +942,8 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="fragmentsOrdered" unique="false"
           lowerBound="1" upperBound="-1" eType="#//textrepresentation/Fragment"/>
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="typeConstraint" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
-      <eStructuralFeatures xsi:type="ecore:EAttribute" name="custom" transient="true">
-        <eGenericType eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EMap">
-          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-        </eGenericType>
-      </eStructuralFeatures>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="custom" eType="#//textrepresentation/JSONObjectWrapper"
+          transient="true"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="ParameterFragment" eSuperTypes="#//textrepresentation/Fragment #//textrepresentation/ParameterReference">
       <eOperations name="getType" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/qualitypatternmodel/model/qualitypatternmodel.ecore
+++ b/qualitypatternmodel/model/qualitypatternmodel.ecore
@@ -927,6 +927,7 @@
           eExceptions="#//patternstructure/InvalidityExceptionWrapper #//operators/OperatorCycleExceptionWrapper #//patternstructure/MissingPatternContainerException"/>
       <eOperations name="generateJSONObject" eType="#//textrepresentation/JSONObjectWrapper"/>
       <eOperations name="generateVariantJSONObject" eType="#//textrepresentation/JSONObjectWrapper"/>
+      <eOperations name="generateCustomAsJson" eType="#//textrepresentation/JSONObjectWrapper"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="pattern" lowerBound="1"
           eType="#//patternstructure/CompletePattern" eOpposite="#//patternstructure/CompletePattern/text"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="fragments" lowerBound="1"
@@ -939,6 +940,12 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="fragmentsOrdered" unique="false"
           lowerBound="1" upperBound="-1" eType="#//textrepresentation/Fragment"/>
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="typeConstraint" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="custom" transient="true">
+        <eGenericType eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EMap">
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+        </eGenericType>
+      </eStructuralFeatures>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="ParameterFragment" eSuperTypes="#//textrepresentation/Fragment #//textrepresentation/ParameterReference">
       <eOperations name="getType" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/qualitypatternmodel/model/qualitypatternmodel.genmodel
+++ b/qualitypatternmodel/model/qualitypatternmodel.genmodel
@@ -782,7 +782,9 @@
         <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateSparqlTemplate"/>
         <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateJSONObject"/>
         <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateVariantJSONObject"/>
-        <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateCustomAsJson"/>
+        <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/addToCustom">
+          <genParameters ecoreParameter="qualitypatternmodel.ecore#//textrepresentation/PatternText/addToCustom/addition"/>
+        </genOperations>
       </genClasses>
       <genClasses ecoreClass="qualitypatternmodel.ecore#//textrepresentation/ParameterFragment">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"

--- a/qualitypatternmodel/model/qualitypatternmodel.genmodel
+++ b/qualitypatternmodel/model/qualitypatternmodel.genmodel
@@ -768,6 +768,7 @@
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference qualitypatternmodel.ecore#//textrepresentation/PatternText/fragmentsOrdered"/>
         <genFeatures createChild="false" ecoreFeature="ecore:EAttribute qualitypatternmodel.ecore#//textrepresentation/PatternText/typeConstraint"/>
+        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute qualitypatternmodel.ecore#//textrepresentation/PatternText/custom"/>
         <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/isValid">
           <genParameters ecoreParameter="qualitypatternmodel.ecore#//textrepresentation/PatternText/isValid/abstractionLevel"/>
         </genOperations>
@@ -781,6 +782,7 @@
         <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateSparqlTemplate"/>
         <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateJSONObject"/>
         <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateVariantJSONObject"/>
+        <genOperations ecoreOperation="qualitypatternmodel.ecore#//textrepresentation/PatternText/generateCustomAsJson"/>
       </genClasses>
       <genClasses ecoreClass="qualitypatternmodel.ecore#//textrepresentation/ParameterFragment">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"

--- a/qualitypatternmodel/openapi.yaml
+++ b/qualitypatternmodel/openapi.yaml
@@ -1518,6 +1518,8 @@ components:
                 - XQuery
                 - Sparql
                 - Cypher
+            custom:
+              type: object
             query:
               type: string
               description: technology-specific query

--- a/qualitypatternmodel/openapi.yaml
+++ b/qualitypatternmodel/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: QPM Constrainify
   description: |-
@@ -1453,6 +1453,8 @@ components:
         name:
           description: identifier of the variant
           type: string
+        custom:
+          type: object
         fragments:
           type: array
           description: fragments of the variant sentence

--- a/qualitypatternmodel/openapi.yaml
+++ b/qualitypatternmodel/openapi.yaml
@@ -1580,6 +1580,8 @@ components:
               constraintName:
                 description: user-defined name of the constraint
                 type: string
+              custom:
+                type: object
               incidents:
                 description: list of found incidents of the constraint in the file
                 type: array

--- a/qualitypatternmodel/openapi.yaml
+++ b/qualitypatternmodel/openapi.yaml
@@ -271,6 +271,11 @@ paths:
           in: query
           schema:
             type: string
+        - name: custom
+          description: add or override custom attributes of the constraint
+          in: query
+          schema:
+            type: object
         - name: namespace
           description: set the datamodel of the constraint
           in: query
@@ -1469,8 +1474,8 @@ components:
       description: metainformation for templates to be able to create new variants via api
       properties:
         variants: 
-          description: full specification of all existing variants 
           $ref: '#/components/schemas/VariantSpecification'
+          description: full specification of all existing variants
         params:
           type: object
           description: map of parameter id to parameter type

--- a/qualitypatternmodel/openapi.yaml
+++ b/qualitypatternmodel/openapi.yaml
@@ -1228,6 +1228,12 @@ components:
         name:
           type: string
           description: variant id
+        typeConstraint:
+          type: boolean
+          description: is formulated as constraint
+        custom:
+          type: object
+          description: custom parameters
         fragments:
           type: array
           description: fragments of the sentence which comprises parameter specifications and text fragments and to set the context of the parameters

--- a/qualitypatternmodel/src/qualitypatternmodel/graphstructure/impl/NodeImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/graphstructure/impl/NodeImpl.java
@@ -33,7 +33,6 @@ import qualitypatternmodel.exceptions.InvalidityException;
 import qualitypatternmodel.exceptions.MissingPatternContainerException;
 import qualitypatternmodel.exceptions.OperatorCycleException;
 import qualitypatternmodel.graphstructure.Adaptable;
-import qualitypatternmodel.graphstructure.Comparable;
 import qualitypatternmodel.graphstructure.ComplexNode;
 import qualitypatternmodel.graphstructure.Graph;
 import qualitypatternmodel.graphstructure.GraphstructurePackage;
@@ -415,10 +414,10 @@ public class NodeImpl extends PatternElementImpl implements Node {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	@Override
-	public Comparison addComparison(Comparable comparable) {
+	public Comparison addComparison(qualitypatternmodel.graphstructure.Comparable comparable) {
 		if (this.getClass() == NodeImpl.class)
 			throw new RuntimeException("Adding Condition Failed: argument is a generic node");
 		if (comparable == null) {
@@ -1922,7 +1921,7 @@ public class NodeImpl extends PatternElementImpl implements Node {
 			case GraphstructurePackage.NODE___IS_OPERATOR_ARGUMENT:
 				return isOperatorArgument();
 			case GraphstructurePackage.NODE___ADD_COMPARISON__COMPARABLE:
-				return addComparison((Comparable)arguments.get(0));
+				return addComparison((qualitypatternmodel.graphstructure.Comparable)arguments.get(0));
 		}
 		return super.eInvoke(operationID, arguments);
 	}

--- a/qualitypatternmodel/src/qualitypatternmodel/graphstructure/impl/NodeImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/graphstructure/impl/NodeImpl.java
@@ -414,7 +414,7 @@ public class NodeImpl extends PatternElementImpl implements Node {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	@Override
 	public Comparison addComparison(qualitypatternmodel.graphstructure.Comparable comparable) {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/ConstraintExecuteServlet.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/ConstraintExecuteServlet.java
@@ -204,6 +204,8 @@ public class ConstraintExecuteServlet extends HttpServlet {
 		object.put(ConstantsJSON.FILE, file.getName());
 		object.put(ConstantsJSON.CONSTRAINT_ID, constraint.getString(ConstantsJSON.CONSTRAINT_ID));
 		object.put(ConstantsJSON.CONSTRAINT_NAME, constraint.getString(ConstantsJSON.NAME));
+		if (constraint.has(ConstantsJSON.CUSTOM))
+			object.put(ConstantsJSON.CUSTOM, constraint.get(ConstantsJSON.CUSTOM));
 
 		String query = constraint.getString(ConstantsJSON.QUERY);
 		String query_partial = constraint.getString(ConstantsJSON.QUERY_PARTIAL);

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/ConstraintQueryServlet.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/ConstraintQueryServlet.java
@@ -20,6 +20,7 @@ import qualitypatternmodel.exceptions.InvalidityException;
 import qualitypatternmodel.javaquery.JavaFilter;
 import qualitypatternmodel.patternstructure.AbstractionLevel;
 import qualitypatternmodel.patternstructure.CompletePattern;
+import qualitypatternmodel.textrepresentation.PatternText;
 import qualitypatternmodel.utility.Constants;
 import qualitypatternmodel.utility.ConstantsError;
 import qualitypatternmodel.utility.ConstantsJSON;
@@ -129,11 +130,16 @@ public class ConstraintQueryServlet extends HttpServlet {
 	static JSONObject generateQueryJson(CompletePattern pattern, String technology) throws JSONException, InvalidServletCallException, FailedServletCallException {
 		JSONObject json = new JSONObject();
 
+		// 1 info
 		json.put(ConstantsJSON.NAME, pattern.getName());
 		json.put(ConstantsJSON.CONSTRAINT_ID, pattern.getPatternId());
-
-		// 1 technology
 		json.put(ConstantsJSON.TECHNOLOGY, pattern.getLanguage().getLiteral());
+		if (pattern.getText() != null && pattern.getText().size()>0) {
+			PatternText text = pattern.getText().get(0);
+			if (text.getCustom() != null && !text.getCustom().isEmpty()) {
+				json.put(ConstantsJSON.CUSTOM, text.getCustom());
+			}
+		}
 
 		// 2 query
 		try {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/ConstraintServlet.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/ConstraintServlet.java
@@ -24,6 +24,7 @@ import qualitypatternmodel.patternstructure.AbstractionLevel;
 import qualitypatternmodel.patternstructure.CompletePattern;
 import qualitypatternmodel.textrepresentation.Fragment;
 import qualitypatternmodel.textrepresentation.ParameterFragment;
+import qualitypatternmodel.textrepresentation.PatternText;
 import qualitypatternmodel.textrepresentation.ValueMap;
 import qualitypatternmodel.textrepresentation.impl.ValueMapImpl;
 import qualitypatternmodel.utility.Constants;
@@ -180,7 +181,7 @@ public class ConstraintServlet extends HttpServlet {
 		}
 
 		// 2. change patterns
-		Boolean name = false, database = false, datamodel = false, namespaces = false, namespacevalid = true;
+		Boolean name = false, database = false, datamodel = false, namespaces = false, namespacevalid = true, custom = false;
 
 		// name?
 		String[] nameArray = parameterMap.get(ConstantsJSON.NAME);
@@ -232,7 +233,21 @@ public class ConstraintServlet extends HttpServlet {
 				}
 				parameterMap.remove(ConstantsJSON.NAMESPACES);
 			} catch (JSONException e) {
-				e.printStackTrace();
+				ServletUtilities.logError(e);
+			}
+		}
+		// custom?
+		String[] customArray = parameterMap.get(ConstantsJSON.CUSTOM);
+		if (customArray != null && customArray.length == 1 && !customArray[0].equals("")) {
+			String customAddition = nameArray[0];
+			try {
+				JSONObject addition = new JSONObject(customAddition);
+				PatternText text = pattern.getText().get(0);
+				text.addToCustom(addition);
+				custom = true;
+				parameterMap.remove(ConstantsJSON.CUSTOM);
+			} catch (Exception e) {
+				ServletUtilities.logError(e);
 			}
 		}
 
@@ -259,7 +274,11 @@ public class ConstraintServlet extends HttpServlet {
 					output.put(ConstantsJSON.FAILED, failed);
 				}
 			}
+			if (custom) {
+				output.getJSONArray(ConstantsJSON.SUCCESS).put(ConstantsJSON.CUSTOM);
+			}
 		} catch (JSONException e) {
+			ServletUtilities.logError(e);
 		}
 
 		// 3. save constraint

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSETANY_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSETANY_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for CompSetAny_xml"
+	},
     "fragments":[
         {"text":"In each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSETISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSETISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for CompSetIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSETSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSETSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for CompSetSin_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSET_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/comp/COMPSET_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for CompSet_xml"
+	},
     "fragments":[
         {"text":"In each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/external/UNIQUE_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/external/UNIQUE_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for Unique_xml. Checks only uniqueness of a value within a file."
+	},	
     "fragments":[
         {"text":"In each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARDCOMPSETIFCOMPSET_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARDCOMPSETIFCOMPSET_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,10 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for CardCompSetIfCompSet_xml. This is a constraint specifically created to check a requirement of a LIDO requirement",
+		"aqindaid": 22
+	},
     "fragments":[
         {"text":"If a"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARDIFCOMPSET_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARDIFCOMPSET_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,10 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for CardIfCompSet_xml. This is a constraint specifically created to check a requirement of a LIDO requirement",
+		"aqindaid": 21
+	},
     "fragments":[
         {"text":"If a"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARDMATCH_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARDMATCH_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,10 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for CardMatch_xml. This is a constraint specifically created to check a requirement of a LIDO requirement",
+		"aqindaid": 31
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARD_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARD_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for Card_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARD_XML_MAND_ELEMENT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/internal/CARD_XML_MAND_ELEMENT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"mand_element",
 	"typeConstraint":true,
+	"custom": {
+		"description": "Same as MandAtt_xml but realized via Card_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/link/VALIDLINKISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/link/VALIDLINKISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for ValidLinkIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/link/VALIDLINKSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/link/VALIDLINKSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for ValidLinkSin_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/link/VALIDLINK_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/link/VALIDLINK_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "Same as MandAtt_xml but realized via ValidLink_xml"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDATT_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDATT_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandAtt_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDISO_XML_CONSTRAINT_2.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDISO_XML_CONSTRAINT_2.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"constraint_2",
 	"typeConstraint":true,
+	"custom": {
+		"description": "simplified constraint for MandContAndIso_xml"
+	},
     "fragments":[
 		{"text":"For all"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandContAndIso_xml"
+	},
     "fragments":[
 		{"text":"For all"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDSIN_XML_CONSTRAINT_2.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDSIN_XML_CONSTRAINT_2.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"constraint_2",
 	"typeConstraint":true,
+	"custom": {
+		"description": "simplified constraint for MandContAndSin_xml"
+	},
     "fragments":[
 		{"text":"Each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTANDSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandContAndSin_xml"
+	},
     "fragments":[
 		{"text":"Each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTAND_XML_CONSTRAINT_2.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTAND_XML_CONSTRAINT_2.json
@@ -3,6 +3,9 @@
 	"language":"xml",
 	"name":"constraint_2",
 	"typeConstraint":true,
+	"custom": {
+		"description": "simplified constraint for MandContAnd_xml"
+	},
 	"fragments":[
 		{"text":"For each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTAND_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTAND_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandContAnd_xml"
+	},
     "fragments":[
 		{"text":"For each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTISO_XML_CONSTRAINT2.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTISO_XML_CONSTRAINT2.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"constraint2",
 	"typeConstraint":true,
+	"custom": {
+		"description": "simplified constraint for MandContIso_xml"
+	},
     "fragments":[
 		{"text":"For all"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandContIso_xml"
+	},
     "fragments":[
 		{"text":"For all"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTISO_XML_SOMETHING.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTISO_XML_SOMETHING.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"something",
 	"typeConstraint":true,
+	"custom": {
+		"description": "very simplified constraint for MandContIso_xml"
+	},
     "fragments":[
 		{"text":"For all"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTSIN_XML_CONSTRAINT_2.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTSIN_XML_CONSTRAINT_2.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"constraint_2",
 	"typeConstraint":true,
+	"custom": {
+		"description": "simplified constraint for MandContSin_xml"
+	},
     "fragments":[
 		{"text":"Each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandContSin_xml"
+	},
     "fragments":[
 		{"text":"Each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTSIN_XML_SOMETHING.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONTSIN_XML_SOMETHING.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"something",
 	"typeConstraint":true,
+	"custom": {
+		"description": "very simplified constraint for MandContSin_xml"
+	},
     "fragments":[
 		{"text":"Each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONT_XML_CONSTRAINT_2.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONT_XML_CONSTRAINT_2.json
@@ -3,6 +3,9 @@
 	"language":"xml",
 	"name":"constraint_2",
 	"typeConstraint":true,
+	"custom": {
+		"description": "simplified constraint for MandCont_xml"
+	},
 	"fragments":[
 		{"text":"For each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONT_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONT_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandCont_xml"
+	},
     "fragments":[
 		{"text":"For each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONT_XML_SOMETHING.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDCONT_XML_SOMETHING.json
@@ -3,6 +3,9 @@
 	"language":"xml",
 	"name":"something",
 	"typeConstraint":true,
+	"custom": {
+		"description": "very simple variant for MandCont_xml. Subelements are just not allowed to be empty"
+	},
 	"fragments":[
 		{"text":"For each"},
 		{

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDELE_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/mand/MANDELE_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MandEle_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for ContainsIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSLISTISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSLISTISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for ContainsListIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSLISTSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSLISTSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for ContainsListSin_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSLIST_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSLIST_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for ContainsList_xml"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINSSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for ContainsSin_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINS_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/CONTAINS_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for Contains_xml"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHISO_XML_BCP_LANG.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHISO_XML_BCP_LANG.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"bcp-lang",
 	"typeConstraint":true,
+	"custom": {
+		"description": "constraint for MatchIso_xml specific to the BCP language code format"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MatchIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHISO_XML_ISO_DATE.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHISO_XML_ISO_DATE.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"iso-date",
 	"typeConstraint":true,
+	"custom": {
+		"description": "constraint for MatchIso_xml specific to the ISO date format"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHLISTISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHLISTISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MatchListIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHLISTSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHLISTSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MatchListSin_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHLIST_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHLIST_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MatchList_xml"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHSIN_XML_BCP_LANG.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHSIN_XML_BCP_LANG.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"bcp-lang",
 	"typeConstraint":true,
+	"custom": {
+		"description": "constraint for MatchSin_xml specific to the BCP language code format"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for MatchSin_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHSIN_XML_ISO_DATE.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCHSIN_XML_ISO_DATE.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"iso-date",
 	"typeConstraint":true,
+	"custom": {
+		"description": "constraint for MatchSin_xml specific to the ISO date format"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCH_XML_BCP_LANG.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCH_XML_BCP_LANG.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"bcp-lang",
 	"typeConstraint":true,
+	"custom": {
+		"description": "constraint for Match_xml specific to the BCP language code format"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCH_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCH_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for Match_xml"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCH_XML_ISO_DATE.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/MATCH_XML_ISO_DATE.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"iso-date",
 	"typeConstraint":true,
+	"custom": {
+		"description": "constraint for Match_xml specific to the ISO date format"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for StringLengthIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHRANGEISO_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHRANGEISO_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for StringLengthRangeIso_xml"
+	},
     "fragments":[
         {"text":"For all"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHRANGESIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHRANGESIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for StringLengthRangeSin_xml"
+	},
     "fragments":[
         {"text":"The character length of each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHRANGE_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHRANGE_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for StringLengthRange_xml"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHSIN_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTHSIN_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for StringLengthSin_xml"
+	},
     "fragments":[
         {"text":"Each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTH_XML_DEFAULT_CONSTRAINT.json
+++ b/qualitypatternmodel/src/qualitypatternmodel/newservlets/jsons/xml/string/STRINGLENGTH_XML_DEFAULT_CONSTRAINT.json
@@ -3,6 +3,9 @@
     "language":"xml",
     "name":"default-constraint",
 	"typeConstraint":true,
+	"custom": {
+		"description": "default constraint for StringLength_xml"
+	},
     "fragments":[
         {"text":"For each"},
         {

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/PatternText.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/PatternText.java
@@ -2,6 +2,7 @@
  */
 package qualitypatternmodel.textrepresentation;
 
+import java.util.Map;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.json.JSONObject;
@@ -28,6 +29,7 @@ import qualitypatternmodel.patternstructure.CompletePattern;
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#getParameterPredefinitions <em>Parameter Predefinitions</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#getFragmentsOrdered <em>Fragments Ordered</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#isTypeConstraint <em>Type Constraint</em>}</li>
+ *   <li>{@link qualitypatternmodel.textrepresentation.PatternText#getCustom <em>Custom</em>}</li>
  * </ul>
  *
  * @see qualitypatternmodel.textrepresentation.TextrepresentationPackage#getPatternText()
@@ -144,6 +146,28 @@ public interface PatternText extends EObject {
 	void setTypeConstraint(boolean value);
 
 	/**
+	 * Returns the value of the '<em><b>Custom</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Custom</em>' attribute.
+	 * @see #setCustom(Map)
+	 * @see qualitypatternmodel.textrepresentation.TextrepresentationPackage#getPatternText_Custom()
+	 * @model transient="true"
+	 * @generated
+	 */
+	Map<String, String> getCustom();
+
+	/**
+	 * Sets the value of the '{@link qualitypatternmodel.textrepresentation.PatternText#getCustom <em>Custom</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Custom</em>' attribute.
+	 * @see #getCustom()
+	 * @generated
+	 */
+	void setCustom(Map<String, String> value);
+
+	/**
 	 * <!-- begin-user-doc -->
 	 * Returns a JSON representation of <code>this</code> <code>PatternText</code> and its contents.
 	 *
@@ -194,6 +218,14 @@ public interface PatternText extends EObject {
 	 * @generated
 	 */
 	JSONObject generateVariantJSONObject();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model dataType="qualitypatternmodel.textrepresentation.JSONObjectWrapper"
+	 * @generated
+	 */
+	JSONObject generateCustomAsJson();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/PatternText.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/PatternText.java
@@ -151,7 +151,7 @@ public interface PatternText extends EObject {
 	 * @return the value of the '<em>Custom</em>' attribute.
 	 * @see #setCustom(JSONObject)
 	 * @see qualitypatternmodel.textrepresentation.TextrepresentationPackage#getPatternText_Custom()
-	 * @model dataType="qualitypatternmodel.textrepresentation.JSONObjectWrapper" transient="true"
+	 * @model dataType="qualitypatternmodel.textrepresentation.JSONObjectWrapper"
 	 * @generated
 	 */
 	JSONObject getCustom();

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/PatternText.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/PatternText.java
@@ -2,7 +2,6 @@
  */
 package qualitypatternmodel.textrepresentation;
 
-import java.util.Map;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.json.JSONObject;
@@ -150,12 +149,12 @@ public interface PatternText extends EObject {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Custom</em>' attribute.
-	 * @see #setCustom(Map)
+	 * @see #setCustom(JSONObject)
 	 * @see qualitypatternmodel.textrepresentation.TextrepresentationPackage#getPatternText_Custom()
-	 * @model transient="true"
+	 * @model dataType="qualitypatternmodel.textrepresentation.JSONObjectWrapper" transient="true"
 	 * @generated
 	 */
-	Map<String, String> getCustom();
+	JSONObject getCustom();
 
 	/**
 	 * Sets the value of the '{@link qualitypatternmodel.textrepresentation.PatternText#getCustom <em>Custom</em>}' attribute.
@@ -165,7 +164,7 @@ public interface PatternText extends EObject {
 	 * @see #getCustom()
 	 * @generated
 	 */
-	void setCustom(Map<String, String> value);
+	void setCustom(JSONObject value);
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -222,10 +221,10 @@ public interface PatternText extends EObject {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model dataType="qualitypatternmodel.textrepresentation.JSONObjectWrapper"
+	 * @model additionDataType="qualitypatternmodel.textrepresentation.JSONObjectWrapper"
 	 * @generated
 	 */
-	JSONObject generateCustomAsJson();
+	void addToCustom(JSONObject addition);
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/TextrepresentationPackage.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/TextrepresentationPackage.java
@@ -222,13 +222,13 @@ public interface TextrepresentationPackage extends EPackage {
 	int PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT = 8;
 
 	/**
-	 * The operation id for the '<em>Generate Custom As Json</em>' operation.
+	 * The operation id for the '<em>Add To Custom</em>' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON = 9;
+	int PATTERN_TEXT___ADD_TO_CUSTOM__JSONOBJECT = 9;
 
 	/**
 	 * The number of operations of the '<em>Pattern Text</em>' class.
@@ -1102,14 +1102,14 @@ public interface TextrepresentationPackage extends EPackage {
 	EOperation getPatternText__GenerateVariantJSONObject();
 
 	/**
-	 * Returns the meta object for the '{@link qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson() <em>Generate Custom As Json</em>}' operation.
+	 * Returns the meta object for the '{@link qualitypatternmodel.textrepresentation.PatternText#addToCustom(org.json.JSONObject) <em>Add To Custom</em>}' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the '<em>Generate Custom As Json</em>' operation.
-	 * @see qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson()
+	 * @return the meta object for the '<em>Add To Custom</em>' operation.
+	 * @see qualitypatternmodel.textrepresentation.PatternText#addToCustom(org.json.JSONObject)
 	 * @generated
 	 */
-	EOperation getPatternText__GenerateCustomAsJson();
+	EOperation getPatternText__AddToCustom__JSONObject();
 
 	/**
 	 * Returns the meta object for the '{@link qualitypatternmodel.textrepresentation.PatternText#delete() <em>Delete</em>}' operation.
@@ -1787,12 +1787,12 @@ public interface TextrepresentationPackage extends EPackage {
 		EOperation PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT = eINSTANCE.getPatternText__GenerateVariantJSONObject();
 
 		/**
-		 * The meta object literal for the '<em><b>Generate Custom As Json</b></em>' operation.
+		 * The meta object literal for the '<em><b>Add To Custom</b></em>' operation.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated
 		 */
-		EOperation PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON = eINSTANCE.getPatternText__GenerateCustomAsJson();
+		EOperation PATTERN_TEXT___ADD_TO_CUSTOM__JSONOBJECT = eINSTANCE.getPatternText__AddToCustom__JSONObject();
 
 		/**
 		 * The meta object literal for the '<em><b>Delete</b></em>' operation.

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/TextrepresentationPackage.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/TextrepresentationPackage.java
@@ -123,13 +123,22 @@ public interface TextrepresentationPackage extends EPackage {
 	int PATTERN_TEXT__TYPE_CONSTRAINT = 5;
 
 	/**
+	 * The feature id for the '<em><b>Custom</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PATTERN_TEXT__CUSTOM = 6;
+
+	/**
 	 * The number of structural features of the '<em>Pattern Text</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PATTERN_TEXT_FEATURE_COUNT = 6;
+	int PATTERN_TEXT_FEATURE_COUNT = 7;
 
 	/**
 	 * The operation id for the '<em>Is Valid</em>' operation.
@@ -213,13 +222,22 @@ public interface TextrepresentationPackage extends EPackage {
 	int PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT = 8;
 
 	/**
+	 * The operation id for the '<em>Generate Custom As Json</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON = 9;
+
+	/**
 	 * The number of operations of the '<em>Pattern Text</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PATTERN_TEXT_OPERATION_COUNT = 9;
+	int PATTERN_TEXT_OPERATION_COUNT = 10;
 
 	/**
 	 * The meta object id for the '{@link qualitypatternmodel.textrepresentation.impl.FragmentImpl <em>Fragment</em>}' class.
@@ -1013,6 +1031,17 @@ public interface TextrepresentationPackage extends EPackage {
 	EAttribute getPatternText_TypeConstraint();
 
 	/**
+	 * Returns the meta object for the attribute '{@link qualitypatternmodel.textrepresentation.PatternText#getCustom <em>Custom</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Custom</em>'.
+	 * @see qualitypatternmodel.textrepresentation.PatternText#getCustom()
+	 * @see #getPatternText()
+	 * @generated
+	 */
+	EAttribute getPatternText_Custom();
+
+	/**
 	 * Returns the meta object for the '{@link qualitypatternmodel.textrepresentation.PatternText#generateJSON() <em>Generate JSON</em>}' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1071,6 +1100,16 @@ public interface TextrepresentationPackage extends EPackage {
 	 * @generated
 	 */
 	EOperation getPatternText__GenerateVariantJSONObject();
+
+	/**
+	 * Returns the meta object for the '{@link qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson() <em>Generate Custom As Json</em>}' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the '<em>Generate Custom As Json</em>' operation.
+	 * @see qualitypatternmodel.textrepresentation.PatternText#generateCustomAsJson()
+	 * @generated
+	 */
+	EOperation getPatternText__GenerateCustomAsJson();
 
 	/**
 	 * Returns the meta object for the '{@link qualitypatternmodel.textrepresentation.PatternText#delete() <em>Delete</em>}' operation.
@@ -1692,6 +1731,14 @@ public interface TextrepresentationPackage extends EPackage {
 		EAttribute PATTERN_TEXT__TYPE_CONSTRAINT = eINSTANCE.getPatternText_TypeConstraint();
 
 		/**
+		 * The meta object literal for the '<em><b>Custom</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute PATTERN_TEXT__CUSTOM = eINSTANCE.getPatternText_Custom();
+
+		/**
 		 * The meta object literal for the '<em><b>Generate JSON</b></em>' operation.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -1738,6 +1785,14 @@ public interface TextrepresentationPackage extends EPackage {
 		 * @generated
 		 */
 		EOperation PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT = eINSTANCE.getPatternText__GenerateVariantJSONObject();
+
+		/**
+		 * The meta object literal for the '<em><b>Generate Custom As Json</b></em>' operation.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EOperation PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON = eINSTANCE.getPatternText__GenerateCustomAsJson();
 
 		/**
 		 * The meta object literal for the '<em><b>Delete</b></em>' operation.

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/PatternTextImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/PatternTextImpl.java
@@ -169,18 +169,18 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 		super();
 
 		//template check
-		String template = json.getString("template");
+		String template = json.getString(ConstantsJSON.TEMPLATE);
 		if (!pattern.getPatternId().equals(template)) {
 			throw new InvalidityException("Selected Pattern '" + pattern.getPatternId() + "' does not match '" + template + "'.");
 		}
 		pattern.getLanguage().getLiteral();
-		String language = json.getString("language");
+		String language = json.getString(ConstantsJSON.LANGUAGE);
 		if (!pattern.getLanguage().getLiteral().equals(language)) {
-			throw new InvalidityException("The language of the selected Pattern '" + pattern.getName() + "' is '" + pattern.getLanguage().getLiteral() + "', which does not match '" + language + "'.");
+			throw new InvalidityException("The language of the selected Pattern '" + pattern.getPatternId() + "' is '" + pattern.getLanguage().getLiteral() + "', which does not match '" + language + "'.");
 		}
 
 		// name
-		String name = json.getString("name");
+		String name = json.getString(ConstantsJSON.NAME);
 		if (!name.matches(Constants.ID_REGEX))
 			throw new InvalidityException(ConstantsError.INVALID_VARIANT_ID);
 		this.setName(name);
@@ -191,6 +191,15 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 		}
 		Boolean typeConstraint = json.getBoolean(ConstantsJSON.TYPE_CONSTRAINT);
 		this.setTypeConstraint(typeConstraint);
+		
+		// custom
+		if (json.has(ConstantsJSON.CUSTOM)) {
+			if (json.get(ConstantsJSON.CUSTOM) instanceof JSONObject) {
+				JSONObject custom = json.getJSONObject(ConstantsJSON.CUSTOM);
+				this.setCustom(custom);
+			} else 
+				ServletUtilities.log( "Variant '" + name + " for pattern " + pattern.getPatternId() + " has an invalid JSONObject as " + ConstantsJSON.CUSTOM + " value.");
+		}
 
 		// pattern
 		pattern.getText().add(this);
@@ -467,6 +476,8 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 			for (ParameterPredefinition predefinition: getParameterPredefinitions()) {
 				fragments.put(predefinition.generateVariantJSONObject());
 			}
+			if (custom != null && !custom.isEmpty())
+				result.put(ConstantsJSON.CUSTOM, getCustom());
 			result.put(ConstantsJSON.FRAGMENTS, fragments);
 		} catch (JSONException e) {
 			e.printStackTrace();

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/PatternTextImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/PatternTextImpl.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.common.notify.Notification;
@@ -137,6 +136,16 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 	protected boolean typeConstraint = TYPE_CONSTRAINT_EDEFAULT;
 
 	/**
+	 * The default value of the '{@link #getCustom() <em>Custom</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCustom()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final JSONObject CUSTOM_EDEFAULT = null;
+
+	/**
 	 * The cached value of the '{@link #getCustom() <em>Custom</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -144,7 +153,7 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 	 * @generated
 	 * @ordered
 	 */
-	protected Map<String, String> custom;
+	protected JSONObject custom = CUSTOM_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -359,7 +368,7 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 	 * @generated
 	 */
 	@Override
-	public Map<String, String> getCustom() {
+	public JSONObject getCustom() {
 		return custom;
 	}
 
@@ -370,8 +379,8 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 	 * @generated
 	 */
 	@Override
-	public void setCustom(Map<String, String> newCustom) {
-		Map<String, String> oldCustom = custom;
+	public void setCustom(JSONObject newCustom) {
+		JSONObject oldCustom = custom;
 		custom = newCustom;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, TextrepresentationPackage.PATTERN_TEXT__CUSTOM, oldCustom, custom));
@@ -408,7 +417,11 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 			}
 			json += getFragmentsOrdered().get(i).generateJSON();
 		}
-		json += "]}";
+		json += "]";
+		if (getCustom() != null && !getCustom().isEmpty()){
+			json += ", \"custom\" : " + getCustom().toString();
+		}
+		json += "}";
 		return json;
 	}
 
@@ -425,9 +438,10 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 			}
 			json.put(ConstantsJSON.FRAGMENTS, fragments);
 			json.put(ConstantsJSON.PARAMETER, ServletUtilities.getAvailableParams(getFragmentsOrdered()));
+			if (custom != null && !custom.isEmpty())
+				json.put(ConstantsJSON.CUSTOM, getCustom());
 		} catch (JSONException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			ServletUtilities.logError(e);
 		}
 		return json;
 	}
@@ -467,14 +481,12 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 	 * @generated NOT
 	 */
 	@Override
-	public JSONObject generateCustomAsJson() {
-		JSONObject object = new JSONObject();
-		for (String key: custom.keySet()) {
-			object.put(key, custom.get(key));
-		}
-		return object;
+	public void addToCustom(JSONObject addition) {
+		if (custom == null)
+			setCustom(addition);
+		for (String key: addition.keySet())
+			custom.put(key, addition.get(key));
 	}
-
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -890,7 +902,7 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 				setTypeConstraint((Boolean)newValue);
 				return;
 			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
-				setCustom((Map<String, String>)newValue);
+				setCustom((JSONObject)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -923,7 +935,7 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 				setTypeConstraint(TYPE_CONSTRAINT_EDEFAULT);
 				return;
 			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
-				setCustom((Map<String, String>)null);
+				setCustom(CUSTOM_EDEFAULT);
 				return;
 		}
 		super.eUnset(featureID);
@@ -950,7 +962,7 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 			case TextrepresentationPackage.PATTERN_TEXT__TYPE_CONSTRAINT:
 				return typeConstraint != TYPE_CONSTRAINT_EDEFAULT;
 			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
-				return custom != null;
+				return CUSTOM_EDEFAULT == null ? custom != null : !CUSTOM_EDEFAULT.equals(custom);
 		}
 		return super.eIsSet(featureID);
 	}
@@ -1000,8 +1012,9 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 				return generateJSONObject();
 			case TextrepresentationPackage.PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT:
 				return generateVariantJSONObject();
-			case TextrepresentationPackage.PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON:
-				return generateCustomAsJson();
+			case TextrepresentationPackage.PATTERN_TEXT___ADD_TO_CUSTOM__JSONOBJECT:
+				addToCustom((JSONObject)arguments.get(0));
+				return null;
 		}
 		return super.eInvoke(operationID, arguments);
 	}

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/PatternTextImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/PatternTextImpl.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.common.notify.Notification;
@@ -58,6 +59,7 @@ import qualitypatternmodel.utility.ConstantsJSON;
  *   <li>{@link qualitypatternmodel.textrepresentation.impl.PatternTextImpl#getParameterPredefinitions <em>Parameter Predefinitions</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.impl.PatternTextImpl#getFragmentsOrdered <em>Fragments Ordered</em>}</li>
  *   <li>{@link qualitypatternmodel.textrepresentation.impl.PatternTextImpl#isTypeConstraint <em>Type Constraint</em>}</li>
+ *   <li>{@link qualitypatternmodel.textrepresentation.impl.PatternTextImpl#getCustom <em>Custom</em>}</li>
  * </ul>
  *
  * @generated
@@ -133,6 +135,16 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 	 * @ordered
 	 */
 	protected boolean typeConstraint = TYPE_CONSTRAINT_EDEFAULT;
+
+	/**
+	 * The cached value of the '{@link #getCustom() <em>Custom</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCustom()
+	 * @generated
+	 * @ordered
+	 */
+	protected Map<String, String> custom;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -344,6 +356,31 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Map<String, String> getCustom() {
+		return custom;
+	}
+
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setCustom(Map<String, String> newCustom) {
+		Map<String, String> oldCustom = custom;
+		custom = newCustom;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, TextrepresentationPackage.PATTERN_TEXT__CUSTOM, oldCustom, custom));
+	}
+
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated NOT
 	 */
 	@Override
@@ -421,6 +458,21 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 			e.printStackTrace();
 		}
 		return result;
+	}
+
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	@Override
+	public JSONObject generateCustomAsJson() {
+		JSONObject object = new JSONObject();
+		for (String key: custom.keySet()) {
+			object.put(key, custom.get(key));
+		}
+		return object;
 	}
 
 
@@ -801,6 +853,8 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 				return getFragmentsOrdered();
 			case TextrepresentationPackage.PATTERN_TEXT__TYPE_CONSTRAINT:
 				return isTypeConstraint();
+			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
+				return getCustom();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -835,6 +889,9 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 			case TextrepresentationPackage.PATTERN_TEXT__TYPE_CONSTRAINT:
 				setTypeConstraint((Boolean)newValue);
 				return;
+			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
+				setCustom((Map<String, String>)newValue);
+				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -865,6 +922,9 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 			case TextrepresentationPackage.PATTERN_TEXT__TYPE_CONSTRAINT:
 				setTypeConstraint(TYPE_CONSTRAINT_EDEFAULT);
 				return;
+			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
+				setCustom((Map<String, String>)null);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -889,6 +949,8 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 				return fragmentsOrdered != null && !fragmentsOrdered.isEmpty();
 			case TextrepresentationPackage.PATTERN_TEXT__TYPE_CONSTRAINT:
 				return typeConstraint != TYPE_CONSTRAINT_EDEFAULT;
+			case TextrepresentationPackage.PATTERN_TEXT__CUSTOM:
+				return custom != null;
 		}
 		return super.eIsSet(featureID);
 	}
@@ -938,6 +1000,8 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 				return generateJSONObject();
 			case TextrepresentationPackage.PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT:
 				return generateVariantJSONObject();
+			case TextrepresentationPackage.PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON:
+				return generateCustomAsJson();
 		}
 		return super.eInvoke(operationID, arguments);
 	}
@@ -956,6 +1020,8 @@ public class PatternTextImpl extends MinimalEObjectImpl.Container implements Pat
 		result.append(name);
 		result.append(", typeConstraint: ");
 		result.append(typeConstraint);
+		result.append(", custom: ");
+		result.append(custom);
 		result.append(')');
 		return result.toString();
 	}

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/TextrepresentationPackageImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/TextrepresentationPackageImpl.java
@@ -299,6 +299,16 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 	 * @generated
 	 */
 	@Override
+	public EAttribute getPatternText_Custom() {
+		return (EAttribute)patternTextEClass.getEStructuralFeatures().get(6);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public EOperation getPatternText__GenerateJSON() {
 		return patternTextEClass.getEOperations().get(2);
 	}
@@ -351,6 +361,16 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 	@Override
 	public EOperation getPatternText__GenerateVariantJSONObject() {
 		return patternTextEClass.getEOperations().get(8);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EOperation getPatternText__GenerateCustomAsJson() {
+		return patternTextEClass.getEOperations().get(9);
 	}
 
 	/**
@@ -909,6 +929,7 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		createEReference(patternTextEClass, PATTERN_TEXT__PARAMETER_PREDEFINITIONS);
 		createEReference(patternTextEClass, PATTERN_TEXT__FRAGMENTS_ORDERED);
 		createEAttribute(patternTextEClass, PATTERN_TEXT__TYPE_CONSTRAINT);
+		createEAttribute(patternTextEClass, PATTERN_TEXT__CUSTOM);
 		createEOperation(patternTextEClass, PATTERN_TEXT___IS_VALID__ABSTRACTIONLEVEL);
 		createEOperation(patternTextEClass, PATTERN_TEXT___ADD_FRAGMENT__FRAGMENT);
 		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_JSON);
@@ -918,6 +939,7 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_SPARQL_TEMPLATE);
 		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_JSON_OBJECT);
 		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT);
+		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON);
 
 		parameterFragmentEClass = createEClass(PARAMETER_FRAGMENT);
 		createEAttribute(parameterFragmentEClass, PARAMETER_FRAGMENT__EXAMPLE_VALUE);
@@ -1023,6 +1045,12 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		initEReference(getPatternText_ParameterPredefinitions(), this.getParameterPredefinition(), this.getParameterPredefinition_Patterntext(), "parameterPredefinitions", null, 0, -1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getPatternText_FragmentsOrdered(), this.getFragment(), null, "fragmentsOrdered", null, 1, -1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getPatternText_TypeConstraint(), ecorePackage.getEBoolean(), "typeConstraint", null, 0, 1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		EGenericType g1 = createEGenericType(ecorePackage.getEMap());
+		EGenericType g2 = createEGenericType(ecorePackage.getEString());
+		g1.getETypeArguments().add(g2);
+		g2 = createEGenericType(ecorePackage.getEString());
+		g1.getETypeArguments().add(g2);
+		initEAttribute(getPatternText_Custom(), g1, "custom", null, 0, 1, PatternText.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		EOperation op = initEOperation(getPatternText__IsValid__AbstractionLevel(), null, "isValid", 0, 1, IS_UNIQUE, IS_ORDERED);
 		addEParameter(op, thePatternstructurePackage.getAbstractionLevel(), "abstractionLevel", 0, 1, IS_UNIQUE, IS_ORDERED);
@@ -1048,6 +1076,8 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		initEOperation(getPatternText__GenerateJSONObject(), this.getJSONObjectWrapper(), "generateJSONObject", 0, 1, IS_UNIQUE, IS_ORDERED);
 
 		initEOperation(getPatternText__GenerateVariantJSONObject(), this.getJSONObjectWrapper(), "generateVariantJSONObject", 0, 1, IS_UNIQUE, IS_ORDERED);
+
+		initEOperation(getPatternText__GenerateCustomAsJson(), this.getJSONObjectWrapper(), "generateCustomAsJson", 0, 1, IS_UNIQUE, IS_ORDERED);
 
 		initEClass(parameterFragmentEClass, ParameterFragment.class, "ParameterFragment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getParameterFragment_ExampleValue(), ecorePackage.getEString(), "exampleValue", null, 0, 1, ParameterFragment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -1130,8 +1160,8 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		addEParameter(op, ecorePackage.getEString(), "value", 0, 1, IS_UNIQUE, IS_ORDERED);
 
 		op = initEOperation(getValueMap__AddAll__Map(), null, "addAll", 0, 1, IS_UNIQUE, IS_ORDERED);
-		EGenericType g1 = createEGenericType(ecorePackage.getEMap());
-		EGenericType g2 = createEGenericType(ecorePackage.getEString());
+		g1 = createEGenericType(ecorePackage.getEMap());
+		g2 = createEGenericType(ecorePackage.getEString());
 		g1.getETypeArguments().add(g2);
 		g2 = createEGenericType(ecorePackage.getEString());
 		g1.getETypeArguments().add(g2);

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/TextrepresentationPackageImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/TextrepresentationPackageImpl.java
@@ -1045,7 +1045,7 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		initEReference(getPatternText_ParameterPredefinitions(), this.getParameterPredefinition(), this.getParameterPredefinition_Patterntext(), "parameterPredefinitions", null, 0, -1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getPatternText_FragmentsOrdered(), this.getFragment(), null, "fragmentsOrdered", null, 1, -1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getPatternText_TypeConstraint(), ecorePackage.getEBoolean(), "typeConstraint", null, 0, 1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getPatternText_Custom(), this.getJSONObjectWrapper(), "custom", null, 0, 1, PatternText.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getPatternText_Custom(), this.getJSONObjectWrapper(), "custom", null, 0, 1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		EOperation op = initEOperation(getPatternText__IsValid__AbstractionLevel(), null, "isValid", 0, 1, IS_UNIQUE, IS_ORDERED);
 		addEParameter(op, thePatternstructurePackage.getAbstractionLevel(), "abstractionLevel", 0, 1, IS_UNIQUE, IS_ORDERED);

--- a/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/TextrepresentationPackageImpl.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/textrepresentation/impl/TextrepresentationPackageImpl.java
@@ -369,7 +369,7 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 	 * @generated
 	 */
 	@Override
-	public EOperation getPatternText__GenerateCustomAsJson() {
+	public EOperation getPatternText__AddToCustom__JSONObject() {
 		return patternTextEClass.getEOperations().get(9);
 	}
 
@@ -939,7 +939,7 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_SPARQL_TEMPLATE);
 		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_JSON_OBJECT);
 		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_VARIANT_JSON_OBJECT);
-		createEOperation(patternTextEClass, PATTERN_TEXT___GENERATE_CUSTOM_AS_JSON);
+		createEOperation(patternTextEClass, PATTERN_TEXT___ADD_TO_CUSTOM__JSONOBJECT);
 
 		parameterFragmentEClass = createEClass(PARAMETER_FRAGMENT);
 		createEAttribute(parameterFragmentEClass, PARAMETER_FRAGMENT__EXAMPLE_VALUE);
@@ -1045,12 +1045,7 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		initEReference(getPatternText_ParameterPredefinitions(), this.getParameterPredefinition(), this.getParameterPredefinition_Patterntext(), "parameterPredefinitions", null, 0, -1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getPatternText_FragmentsOrdered(), this.getFragment(), null, "fragmentsOrdered", null, 1, -1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getPatternText_TypeConstraint(), ecorePackage.getEBoolean(), "typeConstraint", null, 0, 1, PatternText.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		EGenericType g1 = createEGenericType(ecorePackage.getEMap());
-		EGenericType g2 = createEGenericType(ecorePackage.getEString());
-		g1.getETypeArguments().add(g2);
-		g2 = createEGenericType(ecorePackage.getEString());
-		g1.getETypeArguments().add(g2);
-		initEAttribute(getPatternText_Custom(), g1, "custom", null, 0, 1, PatternText.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getPatternText_Custom(), this.getJSONObjectWrapper(), "custom", null, 0, 1, PatternText.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		EOperation op = initEOperation(getPatternText__IsValid__AbstractionLevel(), null, "isValid", 0, 1, IS_UNIQUE, IS_ORDERED);
 		addEParameter(op, thePatternstructurePackage.getAbstractionLevel(), "abstractionLevel", 0, 1, IS_UNIQUE, IS_ORDERED);
@@ -1077,7 +1072,8 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 
 		initEOperation(getPatternText__GenerateVariantJSONObject(), this.getJSONObjectWrapper(), "generateVariantJSONObject", 0, 1, IS_UNIQUE, IS_ORDERED);
 
-		initEOperation(getPatternText__GenerateCustomAsJson(), this.getJSONObjectWrapper(), "generateCustomAsJson", 0, 1, IS_UNIQUE, IS_ORDERED);
+		op = initEOperation(getPatternText__AddToCustom__JSONObject(), null, "addToCustom", 0, 1, IS_UNIQUE, IS_ORDERED);
+		addEParameter(op, this.getJSONObjectWrapper(), "addition", 0, 1, IS_UNIQUE, IS_ORDERED);
 
 		initEClass(parameterFragmentEClass, ParameterFragment.class, "ParameterFragment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getParameterFragment_ExampleValue(), ecorePackage.getEString(), "exampleValue", null, 0, 1, ParameterFragment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -1160,8 +1156,8 @@ public class TextrepresentationPackageImpl extends EPackageImpl implements Textr
 		addEParameter(op, ecorePackage.getEString(), "value", 0, 1, IS_UNIQUE, IS_ORDERED);
 
 		op = initEOperation(getValueMap__AddAll__Map(), null, "addAll", 0, 1, IS_UNIQUE, IS_ORDERED);
-		g1 = createEGenericType(ecorePackage.getEMap());
-		g2 = createEGenericType(ecorePackage.getEString());
+		EGenericType g1 = createEGenericType(ecorePackage.getEMap());
+		EGenericType g2 = createEGenericType(ecorePackage.getEString());
 		g1.getETypeArguments().add(g2);
 		g2 = createEGenericType(ecorePackage.getEString());
 		g1.getETypeArguments().add(g2);

--- a/qualitypatternmodel/src/qualitypatternmodel/utility/ConstantsJSON.java
+++ b/qualitypatternmodel/src/qualitypatternmodel/utility/ConstantsJSON.java
@@ -46,6 +46,7 @@ public class ConstantsJSON {
 	public static final String OPTIONS = "options";
 	public static final String TYPEMODIFIABLE = "typeModifiable";
 	public static final String DEPENDANT = "dependant";
+	public static final String CUSTOM = "custom";
 
 	// Parameter Modification
 	public static final String OLD_NAME = "oldName";

--- a/readme_files/variant-definition.md
+++ b/readme_files/variant-definition.md
@@ -87,7 +87,7 @@ To start the definition of a new variant, we create json file with the following
 ```json
 {
     "template": "<templateId>",
-    "technology": "<technology>"
+    "technology": "<technology>",
     "name": "<variantId>",
     "typeConstraint": true,
     "fragments": [ ]


### PR DESCRIPTION
- custom attributes can be defined in variants
- custom attributes can be stored in constraints using the default setParameter API endpoint
- custom attributes are returned when requesting the variant, constraint, compiledConstraint or analysisResult